### PR TITLE
Feature/improve offline flow

### DIFF
--- a/src/modules/households/infra/typeorm/entities/Address.ts
+++ b/src/modules/households/infra/typeorm/entities/Address.ts
@@ -15,7 +15,7 @@ class Address {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
+  @Column({ nullable: true })
   household_id: string;
 
   @OneToOne(() => Household)

--- a/src/modules/interviews/infra/http/controllers/InterviewsController.ts
+++ b/src/modules/interviews/infra/http/controllers/InterviewsController.ts
@@ -6,6 +6,7 @@ import { container } from 'tsyringe';
 import CreateInterviewService from '@modules/interviews/services/CreateInterviewService';
 import ListInterviewsService from '@modules/interviews/services/ListInterviewsService';
 import ListInterviewsByInterviewerService from '@modules/interviews/services/ListInterviewsByInterviewerService';
+import FindInterviewsService from '@modules/interviews/services/FindInterviewService';
 /* import ListinterviewsService from '@modules/interviews/services/ListinterviewsService';
 import UpdateinterviewService from '@modules/interviews/services/UpdateinterviewService';
 import Showinterviewservice from '@modules/interviews/services/ShowinterviewService';
@@ -62,6 +63,17 @@ export default class interviewsController {
 
     return response.json(classToClass(interview));
   }
+
+  public async handleOfflineInterviews(request: Request, response: Response): Promise<Response> {
+    const offlineInterviews = request.body
+
+    const handleFindInterviews = container.resolve(FindInterviewsService);
+
+    const notSavedInterviews = await handleFindInterviews.handleAllOfflineInterviews(offlineInterviews)
+
+    return response.status(201).json(notSavedInterviews)
+  }
+
   /* public async list(request: Request, response: Response): Promise<Response> {
     const listInterviews = container.resolve(ListInterviewsService);
     const interviews = await listInterviews.execute();

--- a/src/modules/interviews/infra/http/controllers/InterviewsController.ts
+++ b/src/modules/interviews/infra/http/controllers/InterviewsController.ts
@@ -69,9 +69,12 @@ export default class interviewsController {
 
     const handleFindInterviews = container.resolve(FindInterviewsService);
 
+    handleFindInterviews.createOfflineRequestBackup(offlineInterviews)
+
     const notSavedInterviews = await handleFindInterviews.handleAllOfflineInterviews(offlineInterviews)
 
     const stillNotSavedInterviews = await handleFindInterviews.handleAllOfflineInterviews(notSavedInterviews)
+
 
     return response.status(201).json(stillNotSavedInterviews)
   }

--- a/src/modules/interviews/infra/http/controllers/InterviewsController.ts
+++ b/src/modules/interviews/infra/http/controllers/InterviewsController.ts
@@ -71,7 +71,9 @@ export default class interviewsController {
 
     const notSavedInterviews = await handleFindInterviews.handleAllOfflineInterviews(offlineInterviews)
 
-    return response.status(201).json(notSavedInterviews)
+    const stillNotSavedInterviews = await handleFindInterviews.handleAllOfflineInterviews(notSavedInterviews)
+
+    return response.status(201).json(stillNotSavedInterviews)
   }
 
   /* public async list(request: Request, response: Response): Promise<Response> {

--- a/src/modules/interviews/infra/http/routes/interviews.routes.ts
+++ b/src/modules/interviews/infra/http/routes/interviews.routes.ts
@@ -18,6 +18,8 @@ interviewsRouter.get('/', interviewsController.list); */
 
 interviewsRouter.post('/', interviewsController.create);
 
+interviewsRouter.post('/handle-offline-data', interviewsController.handleOfflineInterviews);
+
 /* interviewsRouter.put('/', interviewsController.update);
 
 interviewsRouter.delete('/:id', interviewsController.delete); */

--- a/src/modules/interviews/infra/typeorm/entities/Interview.ts
+++ b/src/modules/interviews/infra/typeorm/entities/Interview.ts
@@ -6,24 +6,27 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  OneToMany,
+  OneToOne,
 } from 'typeorm';
 
 import { Exclude } from 'class-transformer';
 
 import User from '@modules/users/infra/typeorm/entities/User';
 import Project from '@modules/projects/infra/typeorm/entities/Project';
+import Person from '@modules/persons/infra/typeorm/entities/Person';
 
 @Entity('interviews')
 class Interview {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
-  interviewer_id: string;
-
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, user => user.interviews)
   @JoinColumn({ name: 'interviewer_id' })
   interviewer: User;
+
+  @Column({ nullable: true })
+  interviewer_id: string;
 
   @Column()
   project_name: string;
@@ -41,10 +44,13 @@ class Interview {
   project: Project;
 
 
-  @Column()
+  @OneToOne(() => Person, { nullable: true })
+  @JoinColumn({ name: 'person_id' })
+  person: Person;
+
+  @Column({ nullable: true })
   @Exclude()
   person_id: string;
-
 
   @Column()
   @Exclude()

--- a/src/modules/interviews/infra/typeorm/repositories/InterviewsRepository.ts
+++ b/src/modules/interviews/infra/typeorm/repositories/InterviewsRepository.ts
@@ -50,21 +50,43 @@ class InterviewsRepository implements IInterviewsRepository {
   }
 
   public async save(interview: Interview): Promise<Interview> {
-    return this.ormRepository.save(interview);
+    return await this.ormRepository.save(interview);
   }
 
   public async list(): Promise<Interview[]> {
-    const interviews = this.ormRepository.find();
+    const interviews = await this.ormRepository.find();
     return interviews;
   }
 
   public async listByInterviewer(interviewer_id: string): Promise<Interview[]> {
-    const interviews = this.ormRepository.find({
+    const interviews = await this.ormRepository.find({
       where: {
         interviewer_id
       }
     });
     return interviews;
+  }
+
+  public async findAlreadyRegistered({
+    person_nome, person_idade, project_number, interviewer_id
+  }: {
+    person_nome: string, person_idade: number, project_number: number, interviewer_id: string
+  }): Promise<Boolean> {
+    const foundInterview: Interview | undefined = await this.ormRepository.findOne({
+      join: { alias: 'interview', innerJoin: { person: 'interview.person' }},
+      where: (qb: any) => {
+        qb.where({
+          project_number,
+          interviewer_id,
+        }).andWhere('person.nome = :person_nome' , { person_nome })
+        .andWhere('person.idade = :person_idade' , { person_idade })
+      }
+    })
+    if (foundInterview) {
+      return true
+    } else {
+      return false
+    }
   }
 
   /*   public async findById(interview_id: string): Promise<Interview | undefined> {

--- a/src/modules/interviews/repositories/IInterviewsRepository.ts
+++ b/src/modules/interviews/repositories/IInterviewsRepository.ts
@@ -6,6 +6,11 @@ export default interface IInterviewsRepository {
   findByPersonId(person_id: string): Promise<Interview | undefined>;
   list(): Promise<Interview[]>
   listByInterviewer(interviewer_id: string): Promise<Interview[]>
+  findAlreadyRegistered({
+    person_nome, person_idade, project_number, interviewer_id
+  }: {
+    person_nome: string, person_idade: number, project_number: number, interviewer_id: string
+  }): Promise<Boolean>
   /*   findById(interview_id: string): Promise<Interview | undefined>;
     list(): Promise<Interview[]>;
     delete(interview_id: string): Promise<void>; */

--- a/src/modules/interviews/services/CreateAllStepsOfOfflineInterview.ts
+++ b/src/modules/interviews/services/CreateAllStepsOfOfflineInterview.ts
@@ -1,0 +1,309 @@
+import Interview from '../infra/typeorm/entities/Interview';
+import { injectable, inject } from 'tsyringe';
+import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
+import IProjectsRepository from '@modules/projects/repositories/IProjectsRepository';
+import IUsersRepository from '@modules/users/repositories/IUsersRepository';
+import { Roles } from '@modules/users/authorization/constants';
+import AppError from '@shared/errors/AppError';
+import IPersonsRepository from '@modules/persons/repositories/IFamilyMembersRepository';
+import IHouseholdsRepository from '@modules/households/repositories/IHouseholdsRepository';
+import CreatePersonService from '@modules/persons/services/CreatePersonService';
+import CreateHouseholdService from '@modules/households/services/CreateHouseholdService';
+import CreateAddressService from '@modules/households/services/CreateAddressService';
+import CreateInterviewService from './CreateInterviewService';
+/* import AppError from '@shared/errors/AppError'; */
+
+interface IRequest {
+  interviewer_id: string;
+  project_name: string;
+  project_number: number;
+  person_id: string;
+  household_id: string;
+  address_id: string;
+  is_complete: boolean;
+  is_complete_with_errors: boolean;
+  interview_type: string;
+  comments: string;
+}
+
+@injectable()
+export default class CreateAllStepsOfOfflineInterview {
+  constructor(
+    private createInterviewService: CreateInterviewService,
+    private createPersonService: CreatePersonService,
+    private createHouseHold: CreateHouseholdService,
+    private createAddress: CreateAddressService,
+    @inject('UsersRepository')
+    private usersRepository: IUsersRepository,
+  ) { }
+
+  public async createAll({
+    person,
+    household,
+    address,
+    interviewData
+  }: any): Promise<Interview> {
+
+    const {
+      interviewer_id,
+      nome,
+      idade,
+      sexo,
+      raca_cor,
+      ler_escrever,
+      escolaridade,
+      situacao_de_trabalho,
+      ocupacao,
+      local_de_trabalho,
+      diagnostico_covid,
+      vacina,
+      nao_tomou_vacina,
+    } = person
+
+    const {
+      local_do_domicilio,
+      morador_de_rua,
+      povos_tradicionais,
+      qual_povo_tradicional,
+      pessoa_de_referencia,
+      idade_pessoa_de_referencia,
+      sexo_pessoa_de_referencia,
+      raca_cor: referencia_raca_cor,
+      ler_escrever: referencia_ler_escrever,
+      escolaridade: referencia_escolaridade,
+      situacao_de_trabalho: referencia_situacao_de_trabalho,
+      ocupacao_profissional: referencia_ocupacao_profissional,
+      local_de_trabalho: referencia_local_de_trabalho,
+      covid_2020,
+      covid_2021,
+      covid_2022,
+      covid_perda,
+      tipo_de_residencia,
+      numero_de_comodos,
+      material_de_construcao,
+      agua_potavel,
+      agua_animais,
+      agua_producao_alimentos,
+      esgoto,
+      numero_de_pessoas,
+      uma_pessoa_domicilio,
+      cinco_anos_ou_mais,
+      entre_6_e_18,
+      entre_19_e_59,
+      sessenta_anos_ou_mais,
+      pessoas_convidadas,
+      nao_sabe_renda,
+      renda_familiar,
+      faixa_de_renda,
+      // D35 - multipla escolha
+      perda_de_emprego,
+      reducao_de_salario,
+      ajuda_financeira,
+      divida,
+      corte_de_gastos,
+      corte_de_gastos_nao_essenciais,
+      ns_nr_trabalho,
+      //
+      educacao_basica_publica,
+      pnae,
+      cadastro_unico,
+      bolsa_familia,
+      bpc,
+      pensao,
+      auxilio_reclusao,
+      cesta_de_alimentos,
+      restaurantes_populares,
+      auxilio_emergencial,
+      auxilio_vezes,
+      ajuda_instituicao_caridade,
+      tipo_de_ajuda,
+      vergonha,
+      produz_alimento,
+      alimento_para_venda,
+      divisao_alimento,
+      dificuldade_venda,
+      nao_vendeu,
+      preocupacao_alimentos,
+      alimentos_acabaram,
+      alimentos_saudaveis,
+      alimentos_poucos_tipos,
+      refeicoes_adulto,
+      adulto_comeu_menos,
+      adulto_fome,
+      adulto_uma_refeicao,
+      como_adquiriu_comida,
+      alteracao_preco_comida,
+      perfil_de_compra,
+      mercado,
+      gastos_alimentacao,
+      // D68 - multipla escolha
+      feijao,
+      arroz,
+      carnes,
+      verduras_legumes,
+      frutas_frescas,
+      leite,
+      hamburguer_embutidos,
+      bebidas_adocadas,
+      macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados,
+      biscoito_recheado_doces_guloseimas,
+    } = household
+
+    const {
+      state,
+      city,
+      post_code,
+      neighborhood,
+      street_or_location,
+      house_number,
+      telephone_number,
+    } = address
+
+    const {
+      comments,
+      interview_type,
+      is_complete,
+      project_number,
+      project_name,
+      is_complete_with_errors
+    } = interviewData
+
+    const checkIsVisitor = await this.usersRepository.findById(interviewer_id);
+
+    if (checkIsVisitor?.role === Roles.VISITOR) {
+      throw new AppError('O usuário não tem permissão para criar entrevistas.');
+    }
+
+    const createPerson = await this.createPersonService.execute({
+      interviewer_id,
+      nome,
+      idade,
+      sexo,
+      raca_cor,
+      ler_escrever,
+      escolaridade,
+      situacao_de_trabalho,
+      ocupacao,
+      local_de_trabalho,
+      diagnostico_covid,
+      vacina,
+      nao_tomou_vacina,
+    })
+
+    const createHouseHold = await this.createHouseHold.execute({
+      person_id: createPerson?.id,
+      local_do_domicilio,
+      morador_de_rua,
+      povos_tradicionais,
+      qual_povo_tradicional,
+      pessoa_de_referencia,
+      idade_pessoa_de_referencia,
+      sexo_pessoa_de_referencia,
+      raca_cor: referencia_raca_cor,
+      ler_escrever: referencia_ler_escrever,
+      escolaridade: referencia_escolaridade,
+      situacao_de_trabalho: referencia_situacao_de_trabalho,
+      ocupacao_profissional: referencia_ocupacao_profissional,
+      local_de_trabalho: referencia_local_de_trabalho,
+      covid_2020,
+      covid_2021,
+      covid_2022,
+      covid_perda,
+      tipo_de_residencia,
+      numero_de_comodos,
+      material_de_construcao,
+      agua_potavel,
+      agua_animais,
+      agua_producao_alimentos,
+      esgoto,
+      numero_de_pessoas,
+      uma_pessoa_domicilio,
+      cinco_anos_ou_mais,
+      entre_6_e_18,
+      entre_19_e_59,
+      sessenta_anos_ou_mais,
+      pessoas_convidadas,
+      nao_sabe_renda,
+      renda_familiar,
+      faixa_de_renda,
+      // D35 - multipla escolha
+      perda_de_emprego,
+      reducao_de_salario,
+      ajuda_financeira,
+      divida,
+      corte_de_gastos,
+      corte_de_gastos_nao_essenciais,
+      ns_nr_trabalho,
+      //
+      educacao_basica_publica,
+      pnae,
+      cadastro_unico,
+      bolsa_familia,
+      bpc,
+      pensao,
+      auxilio_reclusao,
+      cesta_de_alimentos,
+      restaurantes_populares,
+      auxilio_emergencial,
+      auxilio_vezes,
+      ajuda_instituicao_caridade,
+      tipo_de_ajuda,
+      vergonha,
+      produz_alimento,
+      alimento_para_venda,
+      divisao_alimento,
+      dificuldade_venda,
+      nao_vendeu,
+      preocupacao_alimentos,
+      alimentos_acabaram,
+      alimentos_saudaveis,
+      alimentos_poucos_tipos,
+      refeicoes_adulto,
+      adulto_comeu_menos,
+      adulto_fome,
+      adulto_uma_refeicao,
+      como_adquiriu_comida,
+      alteracao_preco_comida,
+      perfil_de_compra,
+      mercado,
+      gastos_alimentacao,
+      // D68 - multipla escolha
+      feijao,
+      arroz,
+      carnes,
+      verduras_legumes,
+      frutas_frescas,
+      leite,
+      hamburguer_embutidos,
+      bebidas_adocadas,
+      macarrao_instantaneo_salgadinhos_de_pacote_biscoitos_salgados,
+      biscoito_recheado_doces_guloseimas,
+    })
+
+    const createAddress = await this.createAddress.execute({
+      household_id: createHouseHold.id,
+      state,
+      city,
+      post_code,
+      neighborhood,
+      street_or_location,
+      house_number,
+      telephone_number,
+    })
+
+    const interview: Interview = await this.createInterviewService.execute({
+      interviewer_id,
+      project_name: project_name.toUpperCase(),
+      project_number,
+      person_id: createPerson?.id,
+      household_id: createHouseHold?.id,
+      address_id:createAddress?.id,
+      is_complete,
+      is_complete_with_errors,
+      interview_type,
+      comments,
+    });
+
+    return interview;
+  }
+}

--- a/src/modules/interviews/services/FindInterviewService.ts
+++ b/src/modules/interviews/services/FindInterviewService.ts
@@ -1,11 +1,13 @@
 import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
 import { injectable, inject } from 'tsyringe';
+import CreateAllStepsOfOfflineInterview from './CreateAllStepsOfOfflineInterview';
 
 @injectable()
 class FindInterviewsService {
   constructor(
     @inject('InterviewsRepository')
     private interviewsRepository: IInterviewsRepository,
+    private createAllStepsOfOfflineInterviewService: CreateAllStepsOfOfflineInterview,
   ) { }
 
   public async handleAllOfflineInterviews(offlineInterviews: any): Promise<any> {
@@ -27,6 +29,12 @@ class FindInterviewsService {
           })
           if (!isSaved) {
             notRegistered.push(offlineInterview)
+            await this.createAllStepsOfOfflineInterviewService.createAll({
+              person: data?.person,
+              household: data?.household,
+              address: data?.address,
+              interviewData: data?.interview
+            })
           }
         }
       })

--- a/src/modules/interviews/services/FindInterviewService.ts
+++ b/src/modules/interviews/services/FindInterviewService.ts
@@ -1,0 +1,56 @@
+import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
+import { injectable, inject } from 'tsyringe';
+
+@injectable()
+class FindInterviewsService {
+  constructor(
+    @inject('InterviewsRepository')
+    private interviewsRepository: IInterviewsRepository,
+  ) { }
+
+  public async handleAllOfflineInterviews(offlineInterviews: any): Promise<any> {
+    const notRegistered: any = []
+    await Promise.all(
+      offlineInterviews?.map(async (offlineInterview: any) => {
+        const data: any = Object.values(offlineInterview)?.[0]
+        const person_nome = data?.person?.nome
+        const person_idade = data?.person?.idade
+        const interviewer_id = data?.person?.interviewer_id
+        const project_number = data?.interview?.project_number
+
+        if (interviewer_id && person_nome && person_idade && project_number) {
+          const isSaved = await this.validateIfInterviewHasBeenRegistered({
+            interviewer_id,
+            person_nome,
+            person_idade,
+            project_number,
+          })
+          if (!isSaved) {
+            notRegistered.push(offlineInterview)
+          }
+        }
+      })
+    )
+    return notRegistered
+  }
+
+
+  private async validateIfInterviewHasBeenRegistered({
+    person_nome,
+    person_idade,
+    project_number,
+    interviewer_id
+  }: {
+    person_nome: string, person_idade: number, project_number: number, interviewer_id: string
+  }): Promise<Boolean> {
+    const isRegistered: Boolean = await this.interviewsRepository.findAlreadyRegistered({
+      interviewer_id,
+      person_nome,
+      person_idade,
+      project_number
+    });
+    return isRegistered
+  }
+}
+
+export default FindInterviewsService;

--- a/src/modules/interviews/services/FindInterviewService.ts
+++ b/src/modules/interviews/services/FindInterviewService.ts
@@ -1,6 +1,7 @@
 import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
 import { injectable, inject } from 'tsyringe';
 import CreateAllStepsOfOfflineInterview from './CreateAllStepsOfOfflineInterview';
+import fs from 'fs';
 
 @injectable()
 class FindInterviewsService {
@@ -9,6 +10,12 @@ class FindInterviewsService {
     private interviewsRepository: IInterviewsRepository,
     private createAllStepsOfOfflineInterviewService: CreateAllStepsOfOfflineInterview,
   ) { }
+
+  public async createOfflineRequestBackup(data: any): Promise<void> {
+    const path = require('path');
+    const backUpName = String('backup-' + new Date().getTime())
+    fs.writeFileSync(path.join(process.cwd(), `src/backups/${backUpName}.json`), JSON.stringify(data), 'utf8' );
+  }
 
   public async handleAllOfflineInterviews(offlineInterviews: any): Promise<any> {
     const notRegistered: any = []

--- a/src/modules/projects/infra/typeorm/entities/Project.ts
+++ b/src/modules/projects/infra/typeorm/entities/Project.ts
@@ -33,7 +33,7 @@ class Project {
   @Column()
   project_number: number;
 
-  @Column("text", { array: true })
+  @Column("text", { array: true, nullable: true })
   organizations: string[];
 
   @CreateDateColumn()

--- a/src/modules/users/infra/typeorm/entities/User.ts
+++ b/src/modules/users/infra/typeorm/entities/User.ts
@@ -4,9 +4,11 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
 import { Exclude, Expose } from 'class-transformer';
 import uploadConfig from '@config/upload';
+import Interview from '@modules/interviews/infra/typeorm/entities/Interview';
 
 
 @Entity('users')
@@ -26,6 +28,9 @@ class User {
   @Column()
   telephone_number: string;
 
+  @OneToMany(() => Interview, interview => interview.interviewer)
+  interviews: Interview[];
+
   @Column()
   @Exclude()
   password: string;
@@ -34,7 +39,7 @@ class User {
   @Column()
   role: string;
 
-  @Column()
+  @Column({ nullable: true })
   avatar: string;
 
   @CreateDateColumn()

--- a/src/shared/infra/typeorm/migrations/1656715314063-UpdateInterviewRelations.ts
+++ b/src/shared/infra/typeorm/migrations/1656715314063-UpdateInterviewRelations.ts
@@ -1,0 +1,56 @@
+import Interview from "@modules/interviews/infra/typeorm/entities/Interview";
+import {MigrationInterface, QueryRunner, TableColumn, TableForeignKey} from "typeorm";
+
+export class UpdateInterviewRelations1656715314063 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      const currentData = await queryRunner.manager.getRepository(Interview).find()
+
+      await queryRunner.changeColumn("interviews", "interviewer_id", new TableColumn({
+        name: 'interviewer_id',
+        type: 'uuid',
+        isNullable: true,
+      }))
+      await queryRunner.changeColumn("interviews", "person_id", new TableColumn({
+        name: 'person_id',
+        type: 'uuid',
+        isNullable: true,
+      }))
+
+      await queryRunner.createForeignKey(
+        'interviews',
+        new TableForeignKey({
+          name: 'PersonId',
+          columnNames: ['person_id'],
+          referencedColumnNames: ['id'],
+          referencedTableName: 'persons',
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        }),
+      );
+      await queryRunner.createForeignKey(
+        'interviews',
+        new TableForeignKey({
+          name: 'InterviewerId',
+          columnNames: ['interviewer_id'],
+          referencedColumnNames: ['id'],
+          referencedTableName: 'users',
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        }),
+      );
+
+      await Promise.all(
+        currentData?.map(async oldData => {
+          await queryRunner.manager.getRepository(Interview).update(oldData.id, {
+            person_id: oldData?.person_id,
+            interviewer_id: oldData?.interviewer_id
+          })
+        })
+      )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
### Descrição


#### Melhorias no fluxo de envio de entrevistas offline

- Implementa migration com relação entre interview - person e interview - interviewer
- Implementa funcionalidade para verificar através de uma solicitação de envio de entrevistas offfline se a entrevista já foi cadastrada
- Implementa funcionalidade que cria uma entrevista offline, caso essa não esteja no sistema ainda
- Implementa backup dos envios de entrevistas offline (futuramente criar uma CRON para limpar a cada +- 42h)