### PR TITLE
Feature/implements filled form

### DIFF
--- a/src/modules/households/infra/typeorm/entities/Address.ts
+++ b/src/modules/households/infra/typeorm/entities/Address.ts
@@ -8,7 +8,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 
-import Household from './Household';
+import Household from '@modules/households/infra/typeorm/entities/Household';
 
 @Entity('addresses')
 class Address {

--- a/src/modules/households/infra/typeorm/entities/Address.ts
+++ b/src/modules/households/infra/typeorm/entities/Address.ts
@@ -8,7 +8,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 
-import Household from '@modules/households/infra/typeorm/entities/Household';
+import Household from './Household'
 
 @Entity('addresses')
 class Address {

--- a/src/modules/interviews/infra/http/controllers/InterviewsController.ts
+++ b/src/modules/interviews/infra/http/controllers/InterviewsController.ts
@@ -7,6 +7,7 @@ import CreateInterviewService from '@modules/interviews/services/CreateInterview
 import ListInterviewsService from '@modules/interviews/services/ListInterviewsService';
 import ListInterviewsByInterviewerService from '@modules/interviews/services/ListInterviewsByInterviewerService';
 import FindInterviewsService from '@modules/interviews/services/FindInterviewService';
+import Interview from '../../typeorm/entities/Interview';
 /* import ListinterviewsService from '@modules/interviews/services/ListinterviewsService';
 import UpdateinterviewService from '@modules/interviews/services/UpdateinterviewService';
 import Showinterviewservice from '@modules/interviews/services/ShowinterviewService';
@@ -62,6 +63,13 @@ export default class interviewsController {
     const interview = await listInterviews.execute({ interviewer_id: id });
 
     return response.json(classToClass(interview));
+  }
+
+  public async getInterviewById(request: Request, response: Response): Promise<Response> {
+    const { interviewId } = request.params;
+    const getInterview = container.resolve(ListInterviewsService);
+    const interview = await getInterview.findOne(interviewId)
+    return response.json(classToClass(interview))
   }
 
   public async handleOfflineInterviews(request: Request, response: Response): Promise<Response> {

--- a/src/modules/interviews/infra/http/routes/interviews.routes.ts
+++ b/src/modules/interviews/infra/http/routes/interviews.routes.ts
@@ -12,6 +12,8 @@ interviewsRouter.get('/', interviewsController.list);
 
 interviewsRouter.get('/:id', interviewsController.listByInterviewer);
 
+interviewsRouter.get('/get-one/:interviewId', interviewsController.getInterviewById);
+
 /* interviewsRouter.get('/:id', interviewsController.show);
 
 interviewsRouter.get('/', interviewsController.list); */

--- a/src/modules/interviews/infra/typeorm/entities/Interview.ts
+++ b/src/modules/interviews/infra/typeorm/entities/Interview.ts
@@ -15,6 +15,8 @@ import { Exclude } from 'class-transformer';
 import User from '@modules/users/infra/typeorm/entities/User';
 import Project from '@modules/projects/infra/typeorm/entities/Project';
 import Person from '@modules/persons/infra/typeorm/entities/Person';
+import Address from '../../../../households/infra/typeorm/entities/Address';
+import Household from '@modules/households/infra/typeorm/entities/Household';
 
 @Entity('interviews')
 class Interview {
@@ -52,10 +54,20 @@ class Interview {
   @Exclude()
   person_id: string;
 
+
+  @OneToOne(() => Household, { nullable: true })
+  @JoinColumn({ name: 'household_id' })
+  household: Household;
+
+
   @Column()
   @Exclude()
   household_id: string;
 
+
+  @OneToOne(() => Address, { nullable: true })
+  @JoinColumn({ name: 'address_id' })
+  address: Address;
 
   @Column()
   @Exclude()

--- a/src/modules/interviews/infra/typeorm/repositories/InterviewsRepository.ts
+++ b/src/modules/interviews/infra/typeorm/repositories/InterviewsRepository.ts
@@ -2,6 +2,7 @@ import { getRepository, Repository } from 'typeorm';
 import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
 import ICreateInterviewDTO from '@modules/interviews/dtos/ICreateInterviewDTO';
 import Interview from '@modules/interviews/infra/typeorm/entities/Interview';
+import { Exception } from 'handlebars';
 /* import AppError from '@shared/errors/AppError'; */
 
 class InterviewsRepository implements IInterviewsRepository {
@@ -47,6 +48,16 @@ class InterviewsRepository implements IInterviewsRepository {
         person_id
       }
     });
+  }
+
+  public async findOne(interviewId: string): Promise<Interview> {
+    const foundInterview = await this.ormRepository.findOne(interviewId, {
+      relations: ['interviewer', 'person', 'project']
+    })
+    if (!foundInterview) {
+      throw new Exception('INTERVIEW_NOT_FOUND')
+    }
+    return foundInterview
   }
 
   public async save(interview: Interview): Promise<Interview> {

--- a/src/modules/interviews/infra/typeorm/repositories/InterviewsRepository.ts
+++ b/src/modules/interviews/infra/typeorm/repositories/InterviewsRepository.ts
@@ -52,7 +52,7 @@ class InterviewsRepository implements IInterviewsRepository {
 
   public async findOne(interviewId: string): Promise<Interview> {
     const foundInterview = await this.ormRepository.findOne(interviewId, {
-      relations: ['interviewer', 'person', 'project']
+      relations: ['interviewer', 'person', 'project', 'address', 'household']
     })
     if (!foundInterview) {
       throw new Exception('INTERVIEW_NOT_FOUND')

--- a/src/modules/interviews/repositories/IInterviewsRepository.ts
+++ b/src/modules/interviews/repositories/IInterviewsRepository.ts
@@ -11,6 +11,7 @@ export default interface IInterviewsRepository {
   }: {
     person_nome: string, person_idade: number, project_number: number, interviewer_id: string
   }): Promise<Boolean>
+  findOne(interviewId: string): Promise<Interview>
   /*   findById(interview_id: string): Promise<Interview | undefined>;
     list(): Promise<Interview[]>;
     delete(interview_id: string): Promise<void>; */

--- a/src/modules/interviews/services/ListInterviewsService.ts
+++ b/src/modules/interviews/services/ListInterviewsService.ts
@@ -14,6 +14,10 @@ class ListInterviewsService {
     const interviews = await this.interviewsRepository.list();
     return interviews;
   }
+
+  public async findOne(id: string): Promise<Interview> {
+    return await this.interviewsRepository.findOne(id)
+  }
 }
 
 export default ListInterviewsService;

--- a/src/shared/infra/typeorm/migrations/1657485392957-ImprovingInterviewRelations.ts
+++ b/src/shared/infra/typeorm/migrations/1657485392957-ImprovingInterviewRelations.ts
@@ -1,0 +1,57 @@
+import Interview from "@modules/interviews/infra/typeorm/entities/Interview";
+import {MigrationInterface, QueryRunner, TableColumn, TableForeignKey} from "typeorm";
+
+export class ImprovingInterviewRelations1657485392957 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      const currentData = await queryRunner.manager.getRepository(Interview).find()
+
+      await queryRunner.changeColumn("interviews", "address_id", new TableColumn({
+        name: 'address_id',
+        type: 'uuid',
+        isNullable: true,
+      }))
+
+      await queryRunner.createForeignKey(
+        'interviews',
+        new TableForeignKey({
+          name: 'address_id',
+          columnNames: ['address_id'],
+          referencedColumnNames: ['id'],
+          referencedTableName: 'addresses',
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        }),
+      );
+
+      await queryRunner.changeColumn("interviews", "household_id", new TableColumn({
+        name: 'household_id',
+        type: 'uuid',
+        isNullable: true,
+      }))
+
+      await queryRunner.createForeignKey(
+        'interviews',
+        new TableForeignKey({
+          name: 'household_id',
+          columnNames: ['household_id'],
+          referencedColumnNames: ['id'],
+          referencedTableName: 'households',
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        }),
+      );
+
+      await Promise.all(
+        currentData?.map(async oldData => {
+          await queryRunner.manager.getRepository(Interview).save({
+            ...oldData
+          })
+        })
+      )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
### Descrição

- Adiciona nova rota para buscar uma entrevista realizada e seus relacionamentos

URL: `http://localhost:3333/interviews/get-one/$interview_id`,

onde:
$interview_id: Id da entrevista

- Adiciona melhorias no relacionamento de uma entrevista (address e household)

Cria `migration` aprimorando os relacionamentos da entidade de entrevistas
