### PR TITLE
[REDE-20] - Remover campos não utilizados do formulário do módulo Alimentação

### DIFF
--- a/src/modules/indigenous/dtos/ICreateIndigenousAlimentacaoNutricaoDTO.ts
+++ b/src/modules/indigenous/dtos/ICreateIndigenousAlimentacaoNutricaoDTO.ts
@@ -27,12 +27,6 @@ export interface ICreateIndigenousAlimentacaoNutricaoDTO {
 
   alimentacao_do_gosto_30d: string;
 
-  consumiram_alimentos_saudaveis_30d: string;
-
-  teve_comida_todos_os_dias_30d: string;
-
-  ficou_sem_comer_nada_30d: string;
-
   sem_consumo_alimentos_cultura_30d: string;
 
   acao_quando_falta_comida: string;

--- a/src/modules/indigenous/infra/typeorm/entities/IndigenousAlimentacaoNutricao.ts
+++ b/src/modules/indigenous/infra/typeorm/entities/IndigenousAlimentacaoNutricao.ts
@@ -49,15 +49,6 @@ export class IndigenousAlimentacaoNutricao {
   alimentacao_do_gosto_30d: string;
 
   @Column()
-  consumiram_alimentos_saudaveis_30d: string;
-
-  @Column()
-  teve_comida_todos_os_dias_30d: string;
-
-  @Column()
-  ficou_sem_comer_nada_30d: string;
-
-  @Column()
   sem_consumo_alimentos_cultura_30d: string;
 
   @Column()

--- a/src/modules/indigenous/repositories/interfaces/ICreateIndigeanousAlimentacaoNutricao.ts
+++ b/src/modules/indigenous/repositories/interfaces/ICreateIndigeanousAlimentacaoNutricao.ts
@@ -27,12 +27,6 @@ export class ICreateIndigenousAlimentacaoNutricao {
 
   alimentacao_do_gosto_30d: string;
 
-  consumiram_alimentos_saudaveis_30d: string;
-
-  teve_comida_todos_os_dias_30d: string;
-
-  ficou_sem_comer_nada_30d: string;
-
   sem_consumo_alimentos_cultura_30d: string;
 
   acao_quando_falta_comida: string;

--- a/src/shared/infra/typeorm/migrations/1665247041586-CreateIndigenousAlimentacaoNutricao.ts
+++ b/src/shared/infra/typeorm/migrations/1665247041586-CreateIndigenousAlimentacaoNutricao.ts
@@ -74,18 +74,6 @@ export class CreateIndigenousAlimentacaoNutricao1665247041586
             type: 'varchar',
           },
           {
-            name: 'consumiram_alimentos_saudaveis_30d',
-            type: 'varchar',
-          },
-          {
-            name: 'teve_comida_todos_os_dias_30d',
-            type: 'varchar',
-          },
-          {
-            name: 'ficou_sem_comer_nada_30d',
-            type: 'varchar',
-          },
-          {
             name: 'sem_consumo_alimentos_cultura_30d',
             type: 'varchar',
           },


### PR DESCRIPTION
Neste PR foi removido do módulo Alimentação e nutrição os seguintes campos:

consumiram_alimentos_saudaveis_30d
teve_comida_todos_os_dias_30d
ficou_sem_comer_nada_30d