### PR TITLE
[REDE - 33] - Corrigir campos do módulo Saúde e Doença no banco de dados

### DIFF
--- a/src/modules/indigenous/dtos/ICreateIndigenousSaudeDoencaDTO.ts
+++ b/src/modules/indigenous/dtos/ICreateIndigenousSaudeDoencaDTO.ts
@@ -5,9 +5,9 @@ export interface ICreateIndigenousSaudeDoencaDTO {
 
   motivo_nao_tomar_vacina_covid: string;
 
-  familiar_morte_covid: string;
+  familiar_morte: string;
 
-  familiar_morte_covid_contribuia_renda_familiar: string;
+  familiar_morte_contribuia_renda_familiar: string;
 
   condicao_de_saude: string;
 

--- a/src/modules/indigenous/infra/typeorm/entities/IndigenousSaudeDoenca.ts
+++ b/src/modules/indigenous/infra/typeorm/entities/IndigenousSaudeDoenca.ts
@@ -16,10 +16,10 @@ export class IndigeanousSaudeDoenca {
   motivo_nao_tomar_vacina_covid: string;
 
   @Column()
-  familiar_morte_covid: string;
+  familiar_morte: string;
 
   @Column()
-  familiar_morte_covid_contribuia_renda_familiar: string;
+  familiar_morte_contribuia_renda_familiar: string;
 
   @Column()
   condicao_de_saude: string;

--- a/src/modules/indigenous/repositories/interfaces/ICreateIndigenousSaudeDoenca.ts
+++ b/src/modules/indigenous/repositories/interfaces/ICreateIndigenousSaudeDoenca.ts
@@ -5,9 +5,9 @@ export interface ICreateIndigenousSaudeDoenca {
 
   motivo_nao_tomar_vacina_covid: string;
 
-  familiar_morte_covid: string;
+  familiar_morte: string;
 
-  familiar_morte_covid_contribuia_renda_familiar: string;
+  familiar_morte_contribuia_renda_familiar: string;
 
   condicao_de_saude: string;
 

--- a/src/shared/infra/typeorm/migrations/1671294011594-ChangeFieldsSaudeDoencaTable.ts
+++ b/src/shared/infra/typeorm/migrations/1671294011594-ChangeFieldsSaudeDoencaTable.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class ChangeFieldsSaudeDoencaTable1671294011594
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn(
+      'saude_doenca_indigena',
+      'familiar_morte_covid',
+    );
+    await queryRunner.dropColumn(
+      'saude_doenca_indigena',
+      'familiar_morte_covid_contribuia_renda_familiar',
+    );
+    await queryRunner.addColumn(
+      'saude_doenca_indigena',
+      new TableColumn({
+        name: 'familiar_morte',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.addColumn(
+      'saude_doenca_indigena',
+      new TableColumn({
+        name: 'familiar_morte_contribuia_renda_familiar',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('saude_doenca_indigena', 'familiar_morte');
+    await queryRunner.dropColumn(
+      'saude_doenca_indigena',
+      'familiar_morte_contribuia_renda_familiar',
+    );
+    await queryRunner.addColumn(
+      'saude_doenca_indigena',
+      new TableColumn({
+        name: 'familiar_morte_covid',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.addColumn(
+      'saude_doenca_indigena',
+      new TableColumn({
+        name: 'familiar_morte_covid_contribuia_renda_familiar',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Tarefa no Jira

https://fsegall.atlassian.net/browse/REDE-33

## Alterações

- Foi removido os campos `familiar_morte_covid` e `familiar_morte_covid_contribuia_renda_familiar` e incluído os campos `familiar_morte` e `familiar_morte_contribuia_renda_familiar`.

## Como testar

- Atualizar a branch e rodar as migrations. (Não há necessidade de drop no database)
- Testar a rota `/indigeanous-interviews/health-desease` com os novos campos.