### PR TITLE
[REDE - 28] - Listagem das entrevistas indígenas com filtro por projeto.

### DIFF
--- a/src/modules/indigenous/infra/http/controllers/ListIndigenousInterviewController.ts
+++ b/src/modules/indigenous/infra/http/controllers/ListIndigenousInterviewController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import { ListIndigenousInterviewService } from '@modules/indigenous/services/ListIndigenousInterviewService';
+
+export class ListIndigenousInterviewController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const listIndigenousInterviewService = container.resolve(
+      ListIndigenousInterviewService,
+    );
+
+    const indigenousInterviews = await listIndigenousInterviewService.execute();
+
+    return response.json(indigenousInterviews);
+  }
+}

--- a/src/modules/indigenous/infra/http/routes/indigeanousInterview.routes.ts
+++ b/src/modules/indigenous/infra/http/routes/indigeanousInterview.routes.ts
@@ -8,6 +8,7 @@ import { CreateIndigeanousInterviewController } from '../controllers/CreateIndig
 import { CreateIndigeanousInterviewDemographyController } from '../controllers/CreateIndigenousInterviewDemographyController';
 import { CreateIndigeanousInterviewResidenceController } from '../controllers/CreateIndigenousInterviewResidenceController';
 import { CreateIndigenousSaudeDoencaController } from '../controllers/CreateIndigenousSaudeDoencaController';
+import { ListIndigenousInterviewController } from '../controllers/ListIndigenousInterviewController';
 
 const indigeanousInterviewRouter = Router();
 
@@ -17,12 +18,14 @@ const createIndigenousInterviewResidenceController = new CreateIndigeanousInterv
 const createIndigenousSaudeDoencaController = new CreateIndigenousSaudeDoencaController();
 const createIndigenousApoioFinanceiroController = new CreateIndigenousApoioEProtecaoController();
 const createIndigenousAlimentacaoNutricaoController = new CreateIndigenousAlimentacaoNutricaoController();
+const listIndigenousInterviewController = new ListIndigenousInterviewController();
 
 indigeanousInterviewRouter.use(ensureAuthenticated);
 indigeanousInterviewRouter.post(
   '/',
   createIndigenousInterviewController.handle,
 );
+indigeanousInterviewRouter.get('/', listIndigenousInterviewController.handle);
 indigeanousInterviewRouter.post(
   '/demography',
   createIndigenousInterviewDemographyController.handle,

--- a/src/modules/indigenous/infra/typeorm/repositories/IndigenousInterviewRepository.ts
+++ b/src/modules/indigenous/infra/typeorm/repositories/IndigenousInterviewRepository.ts
@@ -24,4 +24,8 @@ export class IndigenousInterviewRepository
   async findById(id: string): Promise<IndigenousInterview | undefined> {
     return this.repository.findOne(id);
   }
+
+  async list(): Promise<IndigenousInterview[]> {
+    return this.repository.find();
+  }
 }

--- a/src/modules/indigenous/repositories/IIndigenousInterviewRepository.ts
+++ b/src/modules/indigenous/repositories/IIndigenousInterviewRepository.ts
@@ -4,4 +4,5 @@ import { ICreateIndigenousInterview } from './interfaces/ICreateIndigenousInterv
 export interface IIndigenousInterviewRepository {
   create(data: ICreateIndigenousInterview): Promise<IndigenousInterview>;
   findById(id: string): Promise<IndigenousInterview | undefined>;
+  list(): Promise<IndigenousInterview[]>;
 }

--- a/src/modules/indigenous/services/CreateIndigenousSaudeDoencaService.ts
+++ b/src/modules/indigenous/services/CreateIndigenousSaudeDoencaService.ts
@@ -4,8 +4,8 @@ import AppError from '@shared/errors/AppError';
 
 import { ICreateIndigenousSaudeDoencaDTO } from '../dtos/ICreateIndigenousSaudeDoencaDTO';
 import { IndigeanousSaudeDoenca } from '../infra/typeorm/entities/IndigenousSaudeDoenca';
-import { IIndigenousSaudeDoencaRepository } from '../repositories/IIndigenousSaudeDoencaRepository';
 import { IIndigenousInterviewRepository } from '../repositories/IIndigenousInterviewRepository';
+import { IIndigenousSaudeDoencaRepository } from '../repositories/IIndigenousSaudeDoencaRepository';
 
 @injectable()
 export class CreateIndigeanousSaudeDoencaService {

--- a/src/modules/indigenous/services/ListIndigenousInterviewService.ts
+++ b/src/modules/indigenous/services/ListIndigenousInterviewService.ts
@@ -1,0 +1,15 @@
+import { inject, injectable } from 'tsyringe';
+
+import { IIndigenousInterviewRepository } from '../repositories/IIndigenousInterviewRepository';
+
+@injectable()
+export class ListIndigenousInterviewService {
+  constructor(
+    @inject('IndigeanousInterviewRepository')
+    private readonly indigenousInterviewRepository: IIndigenousInterviewRepository,
+  ) {}
+
+  async execute() {
+    return this.indigenousInterviewRepository.list();
+  }
+}

--- a/src/shared/infra/http/routes/index.ts
+++ b/src/shared/infra/http/routes/index.ts
@@ -25,6 +25,6 @@ routes.use('/interviews', interviewsRouter);
 routes.use('/users', usersRouter);
 routes.use('/sessions', sessionsRouter);
 routes.use('/offline', offlineRouter);
-routes.use('/indigeanous-interviews', indigeanousInterviewRouter);
+routes.use('/indigenous-interviews', indigeanousInterviewRouter);
 
 export default routes;

--- a/src/shared/infra/http/swagger.json
+++ b/src/shared/infra/http/swagger.json
@@ -973,7 +973,7 @@
         }
       }
     },
-    "/indigeanous-interviews": {
+    "/indigenous-interviews": {
       "post": {
         "summary": "",
         "operationId": "post-indigeanous-interviews",
@@ -1050,9 +1050,10 @@
         "tags": [
           "indigeanous-interviews"
         ]
-      }
+      },
+      "parameters": []
     },
-    "/indigeanous-interviews/demography": {
+    "/indigenous-interviews/demography": {
       "post": {
         "summary": "",
         "operationId": "post-indigeanous-interviews-demography",
@@ -1164,9 +1165,10 @@
         "tags": [
           "indigeanous-interviews"
         ]
-      }
+      },
+      "parameters": []
     },
-    "/indigeanous-interviews/residence": {
+    "/indigenous-interviews/residence": {
       "post": {
         "summary": "",
         "operationId": "post-indigeanous-interview-residence",
@@ -1336,7 +1338,7 @@
       },
       "parameters": []
     },
-    "/indigeanous-interviews/health-desease": {
+    "/indigenous-interviews/health-desease": {
       "post": {
         "summary": "",
         "operationId": "post-indigeanous-interviews-health-desease",
@@ -1472,9 +1474,10 @@
         "tags": [
           "indigeanous-interviews"
         ]
-      }
+      },
+      "parameters": []
     },
-    "/indigeanous-interview/support": {
+    "/indigenous-interview/support": {
       "post": {
         "summary": "",
         "operationId": "post-indigeanous-interview-support",
@@ -1626,9 +1629,10 @@
         "tags": [
           "indigeanous-interviews"
         ]
-      }
+      },
+      "parameters": []
     },
-    "/indigeanous-interviews/nutrition": {
+    "/indigenous-interviews/nutrition": {
       "post": {
         "summary": "",
         "operationId": "post-indigeanous-interviews-nutrition",
@@ -1855,6 +1859,83 @@
         },
         "tags": [
           "indigeanous-interviews"
+        ]
+      },
+      "parameters": []
+    },
+    "/indigenous-interview": {
+      "get": {
+        "summary": "Your GET endpoint",
+        "tags": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "municipio": {
+                        "type": "string"
+                      },
+                      "aldeia_comunidade": {
+                        "type": "string"
+                      },
+                      "tipo_comunidade": {
+                        "type": "string"
+                      },
+                      "entrevistador_id": {
+                        "type": "string"
+                      },
+                      "projeto_id": {
+                        "type": "string"
+                      },
+                      "data_entrevista": {
+                        "type": "string"
+                      },
+                      "responsavel_domicilio": {
+                        "type": "boolean"
+                      },
+                      "created_at": {
+                        "type": "string"
+                      },
+                      "updated_at": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-examples": {
+                    "Example 1": [
+                      {
+                        "id": "82d50898-7912-4987-ab7f-85d626a4462e",
+                        "municipio": "Presidente Prudente",
+                        "aldeia_comunidade": "Tupi",
+                        "tipo_comunidade": "reserva",
+                        "entrevistador_id": "cd0e1d98-737f-4335-bf98-bd359ae2fb9e",
+                        "projeto_id": "6bfcb629-dbb1-47c7-88bf-4c7854415238",
+                        "data_entrevista": "2022-12-17T16:25:23.286Z",
+                        "responsavel_domicilio": true,
+                        "created_at": "2022-12-17T19:25:23.381Z",
+                        "updated_at": "2022-12-17T19:25:23.381Z"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-indigenous-interview",
+        "description": "List all indigenous interviews",
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     }


### PR DESCRIPTION
## Tarefa no Jira

https://fsegall.atlassian.net/browse/REDE-28

## Alterações

- Inclusão da rota `[GET] /indigenous-interviews` para listar todas as entrevistas. Neste primeiro momento está sem filtro.
- Alteração da base de rotas `indigeanous-interviews` para `indigenous-interviews`.
- Mudanças no swagger