### PR TITLE
Fix/indigenous offline

### DIFF
--- a/src/modules/indigenous/infra/http/controllers/HandleOfflineInterviewsController.ts
+++ b/src/modules/indigenous/infra/http/controllers/HandleOfflineInterviewsController.ts
@@ -12,8 +12,10 @@ export class HandleOfflinetInterviewsController {
       HandleOfflineInterviewsService,
     );
 
-    await handleOfflineInterviewsService.execute(data);
+    const notSavedInterviews = await handleOfflineInterviewsService.execute(
+      data,
+    );
 
-    return response.status(201).json();
+    return response.status(201).json(notSavedInterviews);
   }
 }

--- a/src/modules/indigenous/services/HandleOfflineInterviewsService.ts
+++ b/src/modules/indigenous/services/HandleOfflineInterviewsService.ts
@@ -2,8 +2,10 @@ import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { inject, injectable } from 'tsyringe';
 
-import Project from '../../projects/infra/typeorm/entities/Project';
+import AppError from '@shared/errors/AppError';
 
+import Project from '../../projects/infra/typeorm/entities/Project';
+import ProjectsRepository from '../../projects/infra/typeorm/repositories/ProjectsRepository';
 import { IHandleOfflineInterviewsDTO } from '../dtos/IHandleOfflineInterviewsDTO';
 import { IIndigenousAlimentacaoNutricaoRepository } from '../repositories/IIndigenousAlimentacaoNutricaoRepository';
 import { IIndigenousApoioEProtecaoRepository } from '../repositories/IIndigenousApoioEProtecaoRepository';
@@ -11,9 +13,6 @@ import { IIndigenousInterviewDemographyRepository } from '../repositories/IIndig
 import { IIndigenousInterviewRepository } from '../repositories/IIndigenousInterviewRepository';
 import { IIndigenousInterviewResidenceRepository } from '../repositories/IIndigenousInterviewResidenceRepository';
 import { IIndigenousSaudeDoencaRepository } from '../repositories/IIndigenousSaudeDoencaRepository';
-
-import ProjectsRepository from '../../projects/infra/typeorm/repositories/ProjectsRepository'
-import AppError from '@shared/errors/AppError';
 
 @injectable()
 export class HandleOfflineInterviewsService {
@@ -42,9 +41,9 @@ export class HandleOfflineInterviewsService {
 
   private createOfflineRequestBackup(data: IHandleOfflineInterviewsDTO[]) {
     const backupFileName = `backup-indigenousInterview-${new Date().getTime()}`;
-    const dirPath = `src/backups`
+    const dirPath = `src/backups`;
     if (!existsSync(dirPath)) {
-      mkdirSync(dirPath, { recursive: true })
+      mkdirSync(dirPath, { recursive: true });
     }
     writeFileSync(
       join(process.cwd(), `${dirPath}/${backupFileName}.json`),
@@ -53,50 +52,67 @@ export class HandleOfflineInterviewsService {
     );
   }
 
-  async execute(data: IHandleOfflineInterviewsDTO[]) {
+  async execute(data: IHandleOfflineInterviewsDTO[]): Promise<any> {
     this.createOfflineRequestBackup(data);
-    const interviewsToSave = Object.values(data[0]).map(async interview => {
+    let notSavedInterviews: any = {};
+    await Promise.all(
+      data?.map(
+        async i =>
+          // eslint-disable-next-line no-return-await
+          await Promise.all(
+            Object.entries(i).map(async ([key, interview]) => {
+              const project = await this.projectsRepository.findByNumber(
+                interview.indigenous_informacoes_basicas.numero_projeto,
+              );
 
-      const project = await this.projectsRepository.findByNumber(interview.indigenous_informacoes_basicas.numero_projeto)
+              if (project === undefined) {
+                notSavedInterviews = {
+                  ...notSavedInterviews,
+                  [key]: interview,
+                };
+                console.log(
+                  `Projeto nº ${interview.indigenous_informacoes_basicas.numero_projeto.toString()} não existe.`,
+                );
+                return;
+              }
 
-      if(project === undefined) {
-        return new AppError("Esse projeto não existe.")
-      }
+              const indigenousInterview = await this.indigenousInterviewRepository.create(
+                {
+                  projeto_id: project.id,
+                  ...interview.indigenous_informacoes_basicas,
+                },
+              );
 
-      const indigenousInterview = await this.indigenousInterviewRepository.create(
-      {projeto_id: project.id,
-      ...interview.indigenous_informacoes_basicas
-      }
-      );
+              await this.indigenousInterviewDemographyRepository.create({
+                ...interview.indigenous_demografico,
+                entrevista_indigena_id: indigenousInterview.id,
+              });
 
-      await this.indigenousInterviewDemographyRepository.create({
-        ...interview.indigenous_demografico,
-        entrevista_indigena_id: indigenousInterview.id,
-      });
+              await this.indigeanousInterviewResidenceRepository.create({
+                ...interview.indigenous_domicilio,
+                veiculos: interview.indigenous_domicilio.veiculos.toString(),
+                destino_lixo_da_residencia: interview.indigenous_domicilio.destino_lixo_da_residencia.toString(),
+                entrevista_indigena_id: indigenousInterview.id,
+              });
 
-      await this.indigeanousInterviewResidenceRepository.create({
-        ...interview.indigenous_domicilio,
-        veiculos: interview.indigenous_domicilio.veiculos.toString(),
-        destino_lixo_da_residencia: interview.indigenous_domicilio.destino_lixo_da_residencia.toString(),
-        entrevista_indigena_id: indigenousInterview.id,
-      });
+              await this.indigeanousSaudeDoencaRepository.create({
+                ...interview.indigenous_saude_doenca,
+                entrevista_indigena_id: indigenousInterview.id,
+              });
 
-      await this.indigeanousSaudeDoencaRepository.create({
-        ...interview.indigenous_saude_doenca,
-        entrevista_indigena_id: indigenousInterview.id,
-      });
+              await this.indigenousAlimentacaoNutricaoRepository.create({
+                ...interview.indigenous_alimentacao_nutricao,
+                entrevista_indigena_id: indigenousInterview.id,
+              });
 
-      await this.indigenousAlimentacaoNutricaoRepository.create({
-        ...interview.indigenous_alimentacao_nutricao,
-        entrevista_indigena_id: indigenousInterview.id,
-      });
-
-      await this.indigenousApoioEProtecaoRepository.create({
-        ...interview.indigenous_apoio_protecao_social,
-        entrevista_indigena_id: indigenousInterview.id,
-      });
-    });
-
-    await Promise.all(interviewsToSave);
+              await this.indigenousApoioEProtecaoRepository.create({
+                ...interview.indigenous_apoio_protecao_social,
+                entrevista_indigena_id: indigenousInterview.id,
+              });
+            }),
+          ),
+      ),
+    );
+    return notSavedInterviews;
   }
 }

--- a/src/modules/interviews/repositories/IInterviewsRepository.ts
+++ b/src/modules/interviews/repositories/IInterviewsRepository.ts
@@ -7,10 +7,13 @@ export default interface IInterviewsRepository {
   list(): Promise<Interview[]>
   listByInterviewer(interviewer_id: string): Promise<Interview[]>
   findAlreadyRegistered({
-    person_nome, person_idade, project_number, interviewer_id
+    person_nome,
+    person_idade,
+    project_number,
+    interviewer_id,
   }: {
     person_nome: string, person_idade: number, project_number: number, interviewer_id: string
-  }): Promise<Boolean>
+  }): Promise<boolean>
   findOne(interviewId: string): Promise<Interview>
   /*   findById(interview_id: string): Promise<Interview | undefined>;
     list(): Promise<Interview[]>;

--- a/src/modules/interviews/services/FindInterviewService.ts
+++ b/src/modules/interviews/services/FindInterviewService.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { join } from 'path';
 import { injectable, inject } from 'tsyringe';
 
 import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
@@ -14,10 +15,13 @@ class FindInterviewsService {
   ) {}
 
   public async createOfflineRequestBackup(data: any): Promise<void> {
-    const path = require('path');
     const backUpName = String(`backup-${new Date().getTime()}`);
+    const dirPath = `src/backups`
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true })
+    }
     fs.writeFileSync(
-      path.join(process.cwd(), `src/backups/${backUpName}.json`),
+      join(process.cwd(), `${dirPath}/${backUpName}.json`),
       JSON.stringify(data),
       'utf8',
     );


### PR DESCRIPTION
## Adiciona melhorias na rota que recebe entrevistas indígenas no formato offline

### Implementa
- Tratativa para retornar para o cliente (WEB) a entrevista que teve erro ao tentar ser persistida no banco

### Ajusta
- Criação de diretório caso não exista, para salvar backup de entrevistas offline normais
- - Criação de diretório caso não exista, para salvar backup de entrevistas offline indígenas