### PR TITLE
Implemented discrimination interview

### DIFF
--- a/src/modules/discriminations/controllers/CreateDiscriminationController.ts
+++ b/src/modules/discriminations/controllers/CreateDiscriminationController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import { CreateDiscriminationService } from '../services/CreateDiscriminationService';
+
+export class CreateDiscriminationController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const data = request.body;
+
+    const createDiscriminationService = container.resolve(
+      CreateDiscriminationService,
+    );
+
+    await createDiscriminationService.execute(data);
+
+    return response.status(201);
+  }
+}

--- a/src/modules/discriminations/dtos/ICreateDiscriminationDTO.ts
+++ b/src/modules/discriminations/dtos/ICreateDiscriminationDTO.ts
@@ -1,0 +1,14 @@
+export interface ICreateDiscriminationDTO {
+  person_id: string;
+  razao_discriminacao: string;
+  seguido_ou_observado: string;
+  ameacado_ou_assediado: string;
+  xingamentos: string;
+  agir_como_se_fossem_melhor_que_voce: string;
+  honestidade: string;
+  medo: string;
+  inteligencia: string;
+  atendimento: string;
+  respeito: string;
+  gentileza: string;
+}

--- a/src/modules/discriminations/infra/http/routes/discrimination.routes.ts
+++ b/src/modules/discriminations/infra/http/routes/discrimination.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+import { CreateDiscriminationController } from '@modules/discriminations/controllers/CreateDiscriminationController';
+
+const createDiscriminationController = new CreateDiscriminationController();
+
+const discriminationRouter = Router();
+
+discriminationRouter.post('/', createDiscriminationController.handle);
+
+export { discriminationRouter };

--- a/src/modules/discriminations/infra/typeorm/entities/Discrimination.ts
+++ b/src/modules/discriminations/infra/typeorm/entities/Discrimination.ts
@@ -1,0 +1,48 @@
+import { Column, Entity, OneToOne, PrimaryColumn } from 'typeorm';
+
+import Person from '@modules/persons/infra/typeorm/entities/Person';
+
+@Entity('discriminations')
+export class Discrimination {
+  @PrimaryColumn()
+  id: string;
+
+  @Column()
+  person_id: string;
+
+  @Column()
+  razao_discriminacao: string;
+
+  @Column()
+  seguido_ou_observado: string;
+
+  @Column()
+  ameacado_ou_assediado: string;
+
+  @Column()
+  xingamentos: string;
+
+  @Column()
+  agir_como_se_fossem_melhor_que_voce: string;
+
+  @Column()
+  honestidade: string;
+
+  @Column()
+  medo: string;
+
+  @Column()
+  inteligencia: string;
+
+  @Column()
+  atendimento: string;
+
+  @Column()
+  respeito: string;
+
+  @Column()
+  gentileza: string;
+
+  @OneToOne(() => Person)
+  person: Person;
+}

--- a/src/modules/discriminations/infra/typeorm/repositories/DiscriminationRepository.ts
+++ b/src/modules/discriminations/infra/typeorm/repositories/DiscriminationRepository.ts
@@ -1,0 +1,20 @@
+import { Repository, getRepository } from 'typeorm';
+
+import { ICreateDiscriminationDTO } from '@modules/discriminations/dtos/ICreateDiscriminationDTO';
+import { IDiscriminationRepository } from '@modules/discriminations/repositories/IDiscriminationRepository';
+
+import { Discrimination } from '../entities/Discrimination';
+
+export class DiscriminationRepository implements IDiscriminationRepository {
+  private repository: Repository<Discrimination>;
+
+  constructor() {
+    this.repository = getRepository(Discrimination);
+  }
+
+  async create(data: ICreateDiscriminationDTO): Promise<void> {
+    const discrimination = this.repository.create(data);
+
+    await this.repository.save(discrimination);
+  }
+}

--- a/src/modules/discriminations/repositories/IDiscriminationRepository.ts
+++ b/src/modules/discriminations/repositories/IDiscriminationRepository.ts
@@ -1,0 +1,5 @@
+import { ICreateDiscriminationDTO } from '../dtos/ICreateDiscriminationDTO';
+
+export interface IDiscriminationRepository {
+  create(data: ICreateDiscriminationDTO): Promise<void>;
+}

--- a/src/modules/discriminations/services/CreateDiscriminationService.ts
+++ b/src/modules/discriminations/services/CreateDiscriminationService.ts
@@ -1,0 +1,16 @@
+import { inject, injectable } from 'tsyringe';
+
+import { ICreateDiscriminationDTO } from '../dtos/ICreateDiscriminationDTO';
+import { IDiscriminationRepository } from '../repositories/IDiscriminationRepository';
+
+@injectable()
+export class CreateDiscriminationService {
+  constructor(
+    @inject('DiscriminationRepository')
+    private readonly discriminationRepository: IDiscriminationRepository,
+  ) {}
+
+  async execute(data: ICreateDiscriminationDTO): Promise<void> {
+    return this.discriminationRepository.create(data);
+  }
+}

--- a/src/modules/interviews/infra/typeorm/entities/Interview.ts
+++ b/src/modules/interviews/infra/typeorm/entities/Interview.ts
@@ -1,3 +1,4 @@
+import { Exclude } from 'class-transformer';
 import {
   Entity,
   Column,
@@ -6,17 +7,16 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
-  OneToMany,
   OneToOne,
 } from 'typeorm';
 
-import { Exclude } from 'class-transformer';
-
-import User from '@modules/users/infra/typeorm/entities/User';
-import Project from '@modules/projects/infra/typeorm/entities/Project';
-import Person from '@modules/persons/infra/typeorm/entities/Person';
-import Address from '../../../../households/infra/typeorm/entities/Address';
+import { Discrimination } from '@modules/discriminations/infra/typeorm/entities/Discrimination';
 import Household from '@modules/households/infra/typeorm/entities/Household';
+import Person from '@modules/persons/infra/typeorm/entities/Person';
+import Project from '@modules/projects/infra/typeorm/entities/Project';
+import User from '@modules/users/infra/typeorm/entities/User';
+
+import Address from '../../../../households/infra/typeorm/entities/Address';
 
 @Entity('interviews')
 class Interview {
@@ -45,7 +45,6 @@ class Interview {
   @JoinColumn({ name: 'project_id' })
   project: Project;
 
-
   @OneToOne(() => Person, { nullable: true })
   @JoinColumn({ name: 'person_id' })
   person: Person;
@@ -54,16 +53,13 @@ class Interview {
   @Exclude()
   person_id: string;
 
-
   @OneToOne(() => Household, { nullable: true })
   @JoinColumn({ name: 'household_id' })
   household: Household;
 
-
   @Column()
   @Exclude()
   household_id: string;
-
 
   @OneToOne(() => Address, { nullable: true })
   @JoinColumn({ name: 'address_id' })
@@ -85,8 +81,14 @@ class Interview {
   @Column()
   interview_type: string;
 
+  @Column()
+  discrimination_id: string;
+
   @Column({ nullable: true })
   comments: string;
+
+  @OneToOne(() => Discrimination, { nullable: true, eager: true })
+  discrimination: Discrimination;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -2,6 +2,8 @@ import { container } from 'tsyringe';
 import '@modules/users/providers';
 import './providers';
 
+import { DiscriminationRepository } from '@modules/discriminations/infra/typeorm/repositories/DiscriminationRepository';
+import { IDiscriminationRepository } from '@modules/discriminations/repositories/IDiscriminationRepository';
 import HouseholdsRepository from '@modules/households/infra/typeorm/repositories/HouseholdsRepository';
 import IHouseholdsRepository from '@modules/households/repositories/IHouseholdsRepository';
 import { IndigeanousApoioRepository } from '@modules/indigenous/infra/typeorm/repositories/IndigeanousApoioRepository';
@@ -12,10 +14,10 @@ import { IndigeanousInterviewResidenceRepository } from '@modules/indigenous/inf
 import { IndigenousSaudeDoencaRepository } from '@modules/indigenous/infra/typeorm/repositories/IndigenousSaudeDoencaRepository';
 import { IIndigenousAlimentacaoNutricaoRepository } from '@modules/indigenous/repositories/IIndigenousAlimentacaoNutricaoRepository';
 import { IIndigenousApoioEProtecaoRepository } from '@modules/indigenous/repositories/IIndigenousApoioEProtecaoRepository';
-import { IIndigenousInterviewResidenceRepository } from '@modules/indigenous/repositories/IIndigenousInterviewResidenceRepository';
-import { IIndigenousSaudeDoencaRepository } from '@modules/indigenous/repositories/IIndigenousSaudeDoencaRepository';
 import { IIndigenousInterviewDemographyRepository } from '@modules/indigenous/repositories/IIndigenousInterviewDemographyRepository';
 import { IIndigenousInterviewRepository } from '@modules/indigenous/repositories/IIndigenousInterviewRepository';
+import { IIndigenousInterviewResidenceRepository } from '@modules/indigenous/repositories/IIndigenousInterviewResidenceRepository';
+import { IIndigenousSaudeDoencaRepository } from '@modules/indigenous/repositories/IIndigenousSaudeDoencaRepository';
 import InterviewsRepository from '@modules/interviews/infra/typeorm/repositories/InterviewsRepository';
 import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
 import FamilyMembersRepository from '@modules/persons/infra/typeorm/repositories/FamilyMembersRepository';
@@ -92,4 +94,9 @@ container.registerSingleton<IIndigenousApoioEProtecaoRepository>(
 container.registerSingleton<IIndigenousAlimentacaoNutricaoRepository>(
   'IndigeanousAlimentacaoNutricaoRepository',
   IndigenousAlimentacaoNutricaoRepository,
+);
+
+container.registerSingleton<IDiscriminationRepository>(
+  'DiscriminationRepository',
+  DiscriminationRepository,
 );

--- a/src/shared/infra/http/routes/index.ts
+++ b/src/shared/infra/http/routes/index.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 
+import { discriminationRouter } from '@modules/discriminations/infra/http/routes/discrimination.routes';
 import addressesRouter from '@modules/households/infra/http/routes/addresses.routes';
 import householdsRouter from '@modules/households/infra/http/routes/households.routes';
 import { indigeanousInterviewRouter } from '@modules/indigenous/infra/http/routes/indigeanousInterview.routes';
@@ -26,5 +27,6 @@ routes.use('/users', usersRouter);
 routes.use('/sessions', sessionsRouter);
 routes.use('/offline', offlineRouter);
 routes.use('/indigenous-interviews', indigeanousInterviewRouter);
+routes.use('/interviews/discrimination', discriminationRouter);
 
 export default routes;

--- a/src/shared/infra/http/swagger.json
+++ b/src/shared/infra/http/swagger.json
@@ -55,9 +55,7 @@
   "paths": {
     "/projects": {
       "post": {
-        "tags": [
-          "projects"
-        ],
+        "tags": ["projects"],
         "summary": "Adds a new project to the research",
         "description": "",
         "operationId": "addProject",
@@ -84,9 +82,7 @@
     },
     "/interviews": {
       "post": {
-        "tags": [
-          "interviews"
-        ],
+        "tags": ["interviews"],
         "summary": "Adds a new interview to the project",
         "description": "",
         "operationId": "addInterview",
@@ -113,9 +109,7 @@
     },
     "/persons": {
       "get": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Lists all persons that were interviewed",
         "description": "",
         "operationId": "listPersons",
@@ -152,9 +146,7 @@
         }
       },
       "post": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Add a person that was interviewed",
         "description": "",
         "operationId": "addPerson",
@@ -179,9 +171,7 @@
         }
       },
       "put": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Update an existing person",
         "description": "",
         "operationId": "updatePerson",
@@ -214,9 +204,7 @@
     },
     "/persons/{personId}": {
       "get": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Find person by ID",
         "description": "Returns a single person",
         "operationId": "getPersonById",
@@ -264,9 +252,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Deletes a person",
         "description": "",
         "operationId": "deletePerson",
@@ -304,9 +290,7 @@
     },
     "/persons/{personId}/household": {
       "get": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Returns a household",
         "description": "",
         "operationId": "getHouseholdByPersonId",
@@ -356,9 +340,7 @@
     },
     "/persons/{personId}/family": {
       "get": {
-        "tags": [
-          "persons"
-        ],
+        "tags": ["persons"],
         "summary": "Returns family members",
         "description": null,
         "operationId": "getFamilyByPersonId",
@@ -414,9 +396,7 @@
     },
     "/households": {
       "get": {
-        "tags": [
-          "households"
-        ],
+        "tags": ["households"],
         "summary": "Lists all households",
         "description": "",
         "operationId": "listHouseholds",
@@ -453,9 +433,7 @@
         }
       },
       "post": {
-        "tags": [
-          "households"
-        ],
+        "tags": ["households"],
         "summary": "Add a household of an interviewed person",
         "description": "",
         "operationId": "addHousehold",
@@ -494,9 +472,7 @@
     },
     "/familymembers": {
       "get": {
-        "tags": [
-          "familymembers"
-        ],
+        "tags": ["familymembers"],
         "summary": "Lists all family members",
         "description": "",
         "operationId": "listFamilyMembers",
@@ -536,9 +512,7 @@
         }
       },
       "post": {
-        "tags": [
-          "familymembers"
-        ],
+        "tags": ["familymembers"],
         "summary": "Add a family member of an interviewed person",
         "description": "",
         "operationId": "addFamilyMember",
@@ -565,9 +539,7 @@
     },
     "/addresses": {
       "get": {
-        "tags": [
-          "addresses"
-        ],
+        "tags": ["addresses"],
         "summary": "Lists all addresses",
         "description": "",
         "operationId": "listAddresses",
@@ -604,9 +576,7 @@
         }
       },
       "post": {
-        "tags": [
-          "addresses"
-        ],
+        "tags": ["addresses"],
         "summary": "Add a household address",
         "description": "",
         "operationId": "addAddress",
@@ -645,9 +615,7 @@
     },
     "/addresses/{personId}": {
       "get": {
-        "tags": [
-          "addresses"
-        ],
+        "tags": ["addresses"],
         "summary": "Returns an address",
         "description": "Address of the interviewed person",
         "operationId": "getAddressByPersonId",
@@ -697,9 +665,7 @@
     },
     "/users": {
       "get": {
-        "tags": [
-          "users"
-        ],
+        "tags": ["users"],
         "summary": "Lists all users",
         "description": "",
         "operationId": "listUsers",
@@ -736,9 +702,7 @@
         }
       },
       "post": {
-        "tags": [
-          "users"
-        ],
+        "tags": ["users"],
         "summary": "Create user",
         "description": "This creates an interviewer profile as an user",
         "operationId": "createUser",
@@ -763,9 +727,7 @@
         }
       },
       "put": {
-        "tags": [
-          "users"
-        ],
+        "tags": ["users"],
         "summary": "Update an existing user - Interviewer profile",
         "description": "",
         "operationId": "updateUser",
@@ -798,9 +760,7 @@
     },
     "/users/avatar": {
       "patch": {
-        "tags": [
-          "users"
-        ],
+        "tags": ["users"],
         "summary": "Uploads an user avatar file",
         "description": "",
         "operationId": "uploadAvatar",
@@ -836,9 +796,7 @@
     },
     "/users/{userId}": {
       "get": {
-        "tags": [
-          "users"
-        ],
+        "tags": ["users"],
         "summary": "Find user by ID",
         "description": "Returns a single user",
         "operationId": "getUserById",
@@ -888,9 +846,7 @@
     },
     "/sessions": {
       "post": {
-        "tags": [
-          "sessions"
-        ],
+        "tags": ["sessions"],
         "summary": "Logs user into the system",
         "description": "",
         "operationId": "loginUser",
@@ -921,9 +877,7 @@
     },
     "/password/forgot": {
       "post": {
-        "tags": [
-          "password"
-        ],
+        "tags": ["password"],
         "summary": "Allows user to ask for new password",
         "description": "",
         "operationId": "newPassword",
@@ -954,9 +908,7 @@
     },
     "/password/reset": {
       "post": {
-        "tags": [
-          "password"
-        ],
+        "tags": ["password"],
         "summary": "Allows user to change password",
         "description": "",
         "operationId": "newPassword",
@@ -1047,9 +999,7 @@
             "bearerAuth": []
           }
         ],
-        "tags": [
-          "indigeanous-interviews"
-        ]
+        "tags": ["indigeanous-interviews"]
       },
       "parameters": []
     },
@@ -1162,9 +1112,7 @@
             "bearerAuth": []
           }
         ],
-        "tags": [
-          "indigeanous-interviews"
-        ]
+        "tags": ["indigeanous-interviews"]
       },
       "parameters": []
     },
@@ -1332,9 +1280,7 @@
             "bearerAuth": []
           }
         ],
-        "tags": [
-          "indigeanous-interviews"
-        ]
+        "tags": ["indigeanous-interviews"]
       },
       "parameters": []
     },
@@ -1471,9 +1417,7 @@
             }
           }
         },
-        "tags": [
-          "indigeanous-interviews"
-        ]
+        "tags": ["indigeanous-interviews"]
       },
       "parameters": []
     },
@@ -1626,9 +1570,7 @@
             }
           }
         },
-        "tags": [
-          "indigeanous-interviews"
-        ]
+        "tags": ["indigeanous-interviews"]
       },
       "parameters": []
     },
@@ -1857,9 +1799,7 @@
             }
           }
         },
-        "tags": [
-          "indigeanous-interviews"
-        ]
+        "tags": ["indigeanous-interviews"]
       },
       "parameters": []
     },
@@ -2515,6 +2455,110 @@
           "description": ""
         }
       }
+    },
+    "/interviews/discriminations": {
+      "post": {
+        "summary": "",
+        "operationId": "post-interviews-discriminations",
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        },
+        "x-stoplight": {
+          "id": "y0wv6ay34su1j"
+        },
+        "description": "Create a new discrimination interview",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "person_id": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "6s8kffzjuadd4"
+                    }
+                  },
+                  "razao_discriminacao": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "pstw3cx2sa2li"
+                    }
+                  },
+                  "seguido_ou_observado": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "r50agfgpu9ox8"
+                    }
+                  },
+                  "ameacado_ou_assediado": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "12lzfgepdizg2"
+                    }
+                  },
+                  "xingamentos": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "g2ecjhbmjbp3q"
+                    }
+                  },
+                  "agir_como_se_fossem_melhor_que_voce": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "8ugfwub9oxdsh"
+                    }
+                  },
+                  "honestidade": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "y2y0ym96tlmco"
+                    }
+                  },
+                  "medo": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "zcuri7w3wio5x"
+                    }
+                  },
+                  "inteligencia": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "fuznj7almzrhl"
+                    }
+                  },
+                  "atendimento": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "nl524w6fj6tu2"
+                    }
+                  },
+                  "respeito": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "33ygklk3evhai"
+                    }
+                  },
+                  "gentileza": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "9w49lti5lujq7"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["interviews"]
+      }
     }
   },
   "externalDocs": {
@@ -2757,6 +2801,9 @@
       },
       "Interview": {
         "type": "object",
+        "xml": {
+          "name": "Interview"
+        },
         "properties": {
           "interviewer_id": {
             "type": "string"
@@ -2788,10 +2835,13 @@
           },
           "comments": {
             "type": "string"
+          },
+          "discrimination_id": {
+            "type": "string",
+            "x-stoplight": {
+              "id": "079sxpm82cp3i"
+            }
           }
-        },
-        "xml": {
-          "name": "Interview"
         }
       },
       "Person": {
@@ -2810,11 +2860,7 @@
           "sexo": {
             "type": "string",
             "description": "Person gender",
-            "enum": [
-              "masculino",
-              "feminino",
-              "outro"
-            ]
+            "enum": ["masculino", "feminino", "outro"]
           },
           "raca_cor": {
             "type": "string"
@@ -2861,11 +2907,7 @@
           "sexo": {
             "type": "string",
             "description": "Person gender",
-            "enum": [
-              "masculino",
-              "feminino",
-              "outro"
-            ]
+            "enum": ["masculino", "feminino", "outro"]
           },
           "raca_cor": {
             "type": "string"
@@ -2921,11 +2963,7 @@
           "sexo_pessoa_de_referencia": {
             "type": "string",
             "description": "Person gender",
-            "enum": [
-              "masculino",
-              "feminino",
-              "outro"
-            ]
+            "enum": ["masculino", "feminino", "outro"]
           },
           "raca_cor": {
             "type": "string"
@@ -3176,11 +3214,7 @@
           "gender": {
             "type": "string",
             "description": "Person gender",
-            "enum": [
-              "masculino",
-              "feminino",
-              "outro"
-            ]
+            "enum": ["masculino", "feminino", "outro"]
           },
           "age": {
             "type": "integer",

--- a/src/shared/infra/typeorm/migrations/1697495100878-CreateDiscriminationEntity.ts
+++ b/src/shared/infra/typeorm/migrations/1697495100878-CreateDiscriminationEntity.ts
@@ -1,0 +1,108 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumn,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateDiscriminationEntity1697495100878
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'discriminations',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+          },
+          {
+            name: 'person_id',
+            type: 'uuid',
+          },
+          {
+            name: 'razao_discriminacao',
+            type: 'varchar',
+          },
+          {
+            name: 'seguido_ou_observado',
+            type: 'varchar',
+          },
+          {
+            name: 'ameacado_ou_assediado',
+            type: 'varchar',
+          },
+          {
+            name: 'xingamentos',
+            type: 'varchar',
+          },
+          {
+            name: 'agir_como_se_fossem_melhor_que_voce',
+            type: 'varchar',
+          },
+          {
+            name: 'honestidade',
+            type: 'varchar',
+          },
+          {
+            name: 'medo',
+            type: 'varchar',
+          },
+          {
+            name: 'inteligencia',
+            type: 'varchar',
+          },
+          {
+            name: 'atendimento',
+            type: 'varchar',
+          },
+          {
+            name: 'respeito',
+            type: 'varchar',
+          },
+          {
+            name: 'gentileza',
+            type: 'varchar',
+          },
+        ],
+        foreignKeys: [
+          {
+            name: 'FKDiscriminationPerson',
+            columnNames: ['person_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'persons',
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'interviews',
+      new TableColumn({
+        name: 'discrimination_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'interviews',
+      new TableForeignKey({
+        name: 'FKInterviewsDiscrimination',
+        columnNames: ['discrimination_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'discriminations',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('intervies', 'FKInterviewsDiscrimination');
+    await queryRunner.dropColumn('interviews', 'discrimination_id');
+    await queryRunner.dropTable('discriminations');
+  }
+}


### PR DESCRIPTION
## Qual o problema inicial? 📝
- Há necessidade de implementação no backend do armazenamento das entrevistas sobre discriminação.

## Como esse problema foi resolvido? 🤔
- Foi realizado o desenvolvimento da rota de criação da pesquisa de discriminação, bem como da associação da mesma com a entrevista.

## Como testar? 👀
- Executar o comando `npm install` para atualizar todas as bibliotecas.
- Executar o comando `npm run typeorm migration:run` para rodar as migrations e atualizar o banco de dados.
- Ao acessar uma nova entrevista, deve-se marcar a opção Discriminação e responder todas as questões apresentadas. Estas questões devem ser armazenadas no backend.

## Aguardando 💭
- Implementação das novas rotas no front (disponíveis no swagger)

###### Adicionou uma nova lib ao projeto? ⚙️:
- [ ] Se sim, qual? <!-- Colocar o nome aqui -->
- [X] Não.