### PR TITLE
[REDE-74] - Genérico - Form Saúde Mental - conteúdo - back-end

### DIFF
--- a/src/modules/interviews/dtos/ICreateInterviewLifeQualityMentalHealthDTO.ts
+++ b/src/modules/interviews/dtos/ICreateInterviewLifeQualityMentalHealthDTO.ts
@@ -1,0 +1,23 @@
+export interface ICreateInterviewLifeQualityMentalHealthDTO {
+  interview_id: string;
+  sente_nervoso_tenso_preocupado: string;
+  assusta_com_facilidade: string;
+  sente_triste: string;
+  chora_mais_do_que_costume: string;
+  dores_de_cabeca_frequente: string;
+  dorme_mal: string;
+  desconforto_estomacal: string;
+  ma_digestao: string;
+  falta_de_apetite: string;
+  tremores_maos: string;
+  cansa_com_facilidade: string;
+  dificuldade_tomar_decisao: string;
+  dificuldade_satisfacao_tarefas: string;
+  trabalho_traz_sofrimento: string;
+  cansado_tempo_todo: string;
+  dificuldade_pensar_claramente: string;
+  incapaz_desempenhar_papel_util: string;
+  perdeu_interesse_pelas_coisas: string;
+  dar_fim_a_vida: string;
+  sente_inutil: string;
+}

--- a/src/modules/interviews/infra/http/controllers/InterviewLifeQualityMentalHealthController.ts
+++ b/src/modules/interviews/infra/http/controllers/InterviewLifeQualityMentalHealthController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import { InterviewLifeQualityMentalHealthUseCase } from '@modules/interviews/services/InterviewLifeQualityMentalHealthUseCase';
+
+export class InterviewLifeQualityMentalHealthController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const data = request.body;
+
+    const interviewLifeQualityMentalHealthUseCase = container.resolve(
+      InterviewLifeQualityMentalHealthUseCase,
+    );
+
+    await interviewLifeQualityMentalHealthUseCase.execute(data);
+
+    return response.status(201).json();
+  }
+}

--- a/src/modules/interviews/infra/http/routes/interviews.routes.ts
+++ b/src/modules/interviews/infra/http/routes/interviews.routes.ts
@@ -5,7 +5,11 @@ import { Roles } from '@modules/users/authorization/constants';
 import ensureAuthenticated from '@modules/users/infra/http/middlewares/ensureAuthenticated';
 import Role from '@modules/users/infra/http/middlewares/ensurePermission';
 
+import { InterviewLifeQualityMentalHealthController } from '../controllers/InterviewLifeQualityMentalHealthController';
+
 const interviewsController = new InterviewsController();
+const interviewLifeQualityMentalHealthController =
+  new InterviewLifeQualityMentalHealthController();
 
 const interviewsRouter = Router();
 
@@ -33,6 +37,12 @@ interviewsRouter.post(
   '/',
   Role([Roles.COORDINATOR, Roles.INTERVIEWER, Roles.ADMIN]),
   interviewsController.create,
+);
+
+interviewsRouter.post(
+  '/life-quality/mental-health',
+  Role([Roles.COORDINATOR, Roles.INTERVIEWER, Roles.ADMIN]),
+  interviewLifeQualityMentalHealthController.handle,
 );
 
 interviewsRouter.post(

--- a/src/modules/interviews/infra/typeorm/entities/Interview.ts
+++ b/src/modules/interviews/infra/typeorm/entities/Interview.ts
@@ -17,6 +17,7 @@ import Project from '@modules/projects/infra/typeorm/entities/Project';
 import User from '@modules/users/infra/typeorm/entities/User';
 
 import Address from '../../../../households/infra/typeorm/entities/Address';
+import { InterviewLifeQualityMentalHealth } from './InterviewLifeQualityMentalHealth';
 
 @Entity('interviews')
 class Interview {
@@ -89,6 +90,9 @@ class Interview {
 
   @OneToOne(() => Discrimination, { nullable: true, eager: true })
   discrimination: Discrimination;
+
+  @OneToOne(() => InterviewLifeQualityMentalHealth, { eager: true })
+  mentalHealth: InterviewLifeQualityMentalHealth;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/modules/interviews/infra/typeorm/entities/InterviewLifeQualityMentalHealth.ts
+++ b/src/modules/interviews/infra/typeorm/entities/InterviewLifeQualityMentalHealth.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from 'crypto';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('qualidade_vida_saude_mental_estresse')
+export class InterviewLifeQualityMentalHealth {
+  @PrimaryColumn()
+  id: string;
+
+  @Column()
+  interview_id: string;
+
+  @Column()
+  sente_nervoso_tenso_preocupado: string;
+
+  @Column()
+  assusta_com_facilidade: string;
+
+  @Column()
+  sente_triste: string;
+
+  @Column()
+  chora_mais_do_que_costume: string;
+
+  @Column()
+  dores_de_cabeca_frequente: string;
+
+  @Column()
+  dorme_mal: string;
+
+  @Column()
+  desconforto_estomacal: string;
+
+  @Column()
+  ma_digestao: string;
+
+  @Column()
+  falta_de_apetite: string;
+
+  @Column()
+  tremores_maos: string;
+
+  @Column()
+  cansa_com_facilidade: string;
+
+  @Column()
+  dificuldade_tomar_decisao: string;
+
+  @Column()
+  dificuldade_satisfacao_tarefas: string;
+
+  @Column()
+  trabalho_traz_sofrimento: string;
+
+  @Column()
+  cansado_tempo_todo: string;
+
+  @Column()
+  dificuldade_pensar_claramente: string;
+
+  @Column()
+  incapaz_desempenhar_papel_util: string;
+
+  @Column()
+  perdeu_interesse_pelas_coisas: string;
+
+  @Column()
+  dar_fim_a_vida: string;
+
+  @Column()
+  sente_inutil: string;
+
+  constructor() {
+    if (!this.id) this.id = randomUUID();
+  }
+}

--- a/src/modules/interviews/infra/typeorm/repositories/InterviewLifeQualityMentalHealthRepository.ts
+++ b/src/modules/interviews/infra/typeorm/repositories/InterviewLifeQualityMentalHealthRepository.ts
@@ -1,0 +1,24 @@
+import { Repository, getRepository } from 'typeorm';
+
+import { ICreateInterviewLifeQualityMentalHealthDTO } from '@modules/interviews/dtos/ICreateInterviewLifeQualityMentalHealthDTO';
+import { IInterviewLifeQualityMentalHealthRepository } from '@modules/interviews/repositories/IInterviewLifeQualityMentalHealthRepository';
+
+import { InterviewLifeQualityMentalHealth } from '../entities/InterviewLifeQualityMentalHealth';
+
+export class InterviewLifeQualityMentalHealthRepository
+  implements IInterviewLifeQualityMentalHealthRepository
+{
+  private ormRepository: Repository<InterviewLifeQualityMentalHealth>;
+
+  constructor() {
+    this.ormRepository = getRepository(InterviewLifeQualityMentalHealth);
+  }
+
+  async create(
+    data: ICreateInterviewLifeQualityMentalHealthDTO,
+  ): Promise<void> {
+    const interview = this.ormRepository.create(data);
+
+    await this.ormRepository.save(interview);
+  }
+}

--- a/src/modules/interviews/repositories/IInterviewLifeQualityMentalHealthRepository.ts
+++ b/src/modules/interviews/repositories/IInterviewLifeQualityMentalHealthRepository.ts
@@ -1,0 +1,5 @@
+import { ICreateInterviewLifeQualityMentalHealthDTO } from '../dtos/ICreateInterviewLifeQualityMentalHealthDTO';
+
+export interface IInterviewLifeQualityMentalHealthRepository {
+  create(data: ICreateInterviewLifeQualityMentalHealthDTO): Promise<void>;
+}

--- a/src/modules/interviews/services/InterviewLifeQualityMentalHealthUseCase.ts
+++ b/src/modules/interviews/services/InterviewLifeQualityMentalHealthUseCase.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+
+import { ICreateInterviewLifeQualityMentalHealthDTO } from '../dtos/ICreateInterviewLifeQualityMentalHealthDTO';
+import { IInterviewLifeQualityMentalHealthRepository } from '../repositories/IInterviewLifeQualityMentalHealthRepository';
+
+@injectable()
+export class InterviewLifeQualityMentalHealthUseCase {
+  constructor(
+    @inject('InterviewLifeQualityMentalHealthRepository')
+    private readonly interviewLifeQualityMentalHealthRepository: IInterviewLifeQualityMentalHealthRepository,
+  ) {}
+
+  async execute(
+    data: ICreateInterviewLifeQualityMentalHealthDTO,
+  ): Promise<void> {
+    await this.interviewLifeQualityMentalHealthRepository.create(data);
+  }
+}

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -18,7 +18,9 @@ import { IIndigenousInterviewDemographyRepository } from '@modules/indigenous/re
 import { IIndigenousInterviewRepository } from '@modules/indigenous/repositories/IIndigenousInterviewRepository';
 import { IIndigenousInterviewResidenceRepository } from '@modules/indigenous/repositories/IIndigenousInterviewResidenceRepository';
 import { IIndigenousSaudeDoencaRepository } from '@modules/indigenous/repositories/IIndigenousSaudeDoencaRepository';
+import { InterviewLifeQualityMentalHealthRepository } from '@modules/interviews/infra/typeorm/repositories/InterviewLifeQualityMentalHealthRepository';
 import InterviewsRepository from '@modules/interviews/infra/typeorm/repositories/InterviewsRepository';
+import { IInterviewLifeQualityMentalHealthRepository } from '@modules/interviews/repositories/IInterviewLifeQualityMentalHealthRepository';
 import IInterviewsRepository from '@modules/interviews/repositories/IInterviewsRepository';
 import FamilyMembersRepository from '@modules/persons/infra/typeorm/repositories/FamilyMembersRepository';
 import PersonsRepository from '@modules/persons/infra/typeorm/repositories/PersonsRepository';
@@ -99,4 +101,9 @@ container.registerSingleton<IIndigenousAlimentacaoNutricaoRepository>(
 container.registerSingleton<IDiscriminationRepository>(
   'DiscriminationRepository',
   DiscriminationRepository,
+);
+
+container.registerSingleton<IInterviewLifeQualityMentalHealthRepository>(
+  'InterviewLifeQualityMentalHealthRepository',
+  InterviewLifeQualityMentalHealthRepository,
 );

--- a/src/shared/infra/typeorm/migrations/1701899958334-LifeQualityMentalHealthAndStress.ts
+++ b/src/shared/infra/typeorm/migrations/1701899958334-LifeQualityMentalHealthAndStress.ts
@@ -1,0 +1,118 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class LifeQualityMentalHealthAndStress1701899958334
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'qualidade_vida_saude_mental_estresse',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+          },
+          {
+            name: 'interview_id',
+            type: 'uuid',
+          },
+          {
+            name: 'sente_nervoso_tenso_preocupado',
+            type: 'varchar',
+          },
+          {
+            name: 'assusta_com_facilidade',
+            type: 'varchar',
+          },
+          {
+            name: 'sente_triste',
+            type: 'varchar',
+          },
+          {
+            name: 'chora_mais_do_que_costume',
+            type: 'varchar',
+          },
+          {
+            name: 'dores_de_cabeca_frequente',
+            type: 'varchar',
+          },
+          {
+            name: 'dorme_mal',
+            type: 'varchar',
+          },
+          {
+            name: 'desconforto_estomacal',
+            type: 'varchar',
+          },
+          {
+            name: 'ma_digestao',
+            type: 'varchar',
+          },
+          {
+            name: 'falta_de_apetite',
+            type: 'varchar',
+          },
+          {
+            name: 'tremores_maos',
+            type: 'varchar',
+          },
+          {
+            name: 'cansa_com_facilidade',
+            type: 'varchar',
+          },
+          {
+            name: 'dificuldade_tomar_decisao',
+            type: 'varchar',
+          },
+          {
+            name: 'dificuldade_satisfacao_tarefas',
+            type: 'varchar',
+          },
+          {
+            name: 'trabalho_traz_sofrimento',
+            type: 'varchar',
+          },
+          {
+            name: 'cansado_tempo_todo',
+            type: 'varchar',
+          },
+          {
+            name: 'dificuldade_pensar_claramente',
+            type: 'varchar',
+          },
+          {
+            name: 'incapaz_desempenhar_papel_util',
+            type: 'varchar',
+          },
+          {
+            name: 'perdeu_interesse_pelas_coisas',
+            type: 'varchar',
+          },
+          {
+            name: 'dar_fim_a_vida',
+            type: 'varchar',
+          },
+          {
+            name: 'sente_inutil',
+            type: 'varchar',
+          },
+        ],
+        foreignKeys: [
+          {
+            name: 'FKInterviewToInterviewQualityLifeMentalHealth',
+            columnNames: ['interview_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'interviews',
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('qualidade_vida_saude_mental_estresse');
+  }
+}


### PR DESCRIPTION
## Qual o problema inicial? 📝
https://fsegall.atlassian.net/browse/REDE-73

## Como esse problema foi resolvido? 🤔
Desenvolvido formulário sobre saude mental no módulo qualidade de vida.

## Como testar? 👀
- Executar as migrations.
- Executar a rota `[POST] /interviews/life-quality/mental-health` com os seguintes parâmetros:
```json
{
  "interview_id": "uuid",
  "sente_nervoso_tenso_preocupado": "string",
  "assusta_com_facilidade": "string",
  "sente_triste": "string",
  "chora_mais_do_que_costume": "string",
  "dores_de_cabeca_frequente": "string",
  "dorme_mal": "string",
  "desconforto_estomacal": "string",
  "ma_digestao": "string",
  "falta_de_apetite": "string",
  "tremores_maos": "string",
  "cansa_com_facilidade": "string",
  "dificuldade_tomar_decisao": "string",
  "dificuldade_satisfacao_tarefas": "string",
  "trabalho_traz_sofrimento": "string",
  "cansado_tempo_todo": "string",
  "dificuldade_pensar_claramente": "string",
  "incapaz_desempenhar_papel_util": "string",
  "perdeu_interesse_pelas_coisas": "string",
  "dar_fim_a_vida": "string",
  "sente_inutil": "string"
}
```
## Aguardando 💭
- Desenvolvimento das telas no front-end.

###### Adicionou uma nova lib ao projeto? ⚙️:
- [ ] Se sim, qual? <!-- Colocar o nome aqui -->
- [X] Não.